### PR TITLE
Changes induced by DEF-10288

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func ExampleNewWatcher() {
-	watcher, err := fsnotify.NewWatcher()
+	watcher, err := fsnotify.NewWatcher(fsnotify.DefaultFlags)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/fanotify.go
+++ b/fanotify.go
@@ -1,0 +1,186 @@
+package fsnotify
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+type FanotifyWatcher struct {
+	fd       int
+	done     chan struct{} // Channel for sending a "quit message" to the reader goroutine
+	doneResp chan struct{} // Channel to respond to Close
+	Events   chan Event
+	Errors   chan error
+	poller   *fdPoller
+}
+
+func NewFanotifyWatcher() (*FanotifyWatcher, error) {
+	fd, err := unix.FanotifyInit(unix.FAN_CLASS_NOTIF, unix.O_RDONLY|unix.O_LARGEFILE)
+	if fd < 0 {
+		return nil, err
+	}
+
+	poller, err := newFdPoller(fd)
+	if err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+
+	fw := &FanotifyWatcher{
+		fd:       fd,
+		done:     make(chan struct{}),
+		doneResp: make(chan struct{}),
+		Events:   make(chan Event),
+		Errors:   make(chan error),
+		poller:   poller,
+	}
+	go fw.readEvents()
+	return fw, nil
+}
+
+func (fw *FanotifyWatcher) Add(path string) error {
+	err := unix.FanotifyMark(
+		fw.fd,
+		unix.FAN_MARK_ADD|unix.FAN_MARK_MOUNT,
+		unix.FAN_CLOSE_WRITE,
+		unix.AT_FDCWD,
+		path,
+	)
+	if err != nil {
+		log.Printf("unix.FanotifyMark(%d, ..., %s) failed: %s\n", fw.fd, path, err.Error())
+	}
+	return err
+}
+
+func (fw *FanotifyWatcher) readEvents() {
+	var (
+		buf   [unix.FAN_EVENT_METADATA_LEN * 4096]byte // Buffer for a maximum of 4096 raw events
+		n     int                                      // Number of bytes read with read()
+		errno error                                    // Syscall errno
+		ok    bool                                     // For poller.wait
+	)
+
+	defer close(fw.doneResp)
+	defer close(fw.Errors)
+	defer close(fw.Events)
+	defer unix.Close(fw.fd)
+	defer fw.poller.close()
+
+	for {
+		// See if we have been closed.
+		if fw.isClosed() {
+			return
+		}
+
+		ok, errno = fw.poller.wait()
+		if errno != nil {
+			select {
+			case fw.Errors <- errno:
+			case <-fw.done:
+				return
+			}
+			continue
+		}
+
+		if !ok {
+			continue
+		}
+
+		n, errno = unix.Read(fw.fd, buf[:])
+		// If a signal interrupted execution, see if we've been asked to close, and try again.
+		// http://man7.org/linux/man-pages/man7/signal.7.html :
+		if errno == unix.EINTR {
+			continue
+		}
+
+		// unix.Read might have been woken up by Close. If so, we're done.
+		if fw.isClosed() {
+			return
+		}
+
+		if n < unix.FAN_EVENT_METADATA_LEN {
+			var err error
+			if n == 0 {
+				// If EOF is received. This should really never happen.
+				err = io.EOF
+			} else if n < 0 {
+				// If an error occurred while reading.
+				err = errno
+			} else {
+				// Read was too short.
+				err = errors.New("notify: short read in readEvents()")
+			}
+			select {
+			case fw.Errors <- err:
+			case <-fw.done:
+				return
+			}
+			continue
+		}
+
+		var offset uint32
+		for offset <= uint32(n-unix.FAN_EVENT_METADATA_LEN) {
+			raw := (*unix.FanotifyEventMetadata)(unsafe.Pointer(&buf[offset]))
+			if !(raw.Event_len >= unix.FAN_EVENT_METADATA_LEN && raw.Event_len <= uint32(n)-offset) {
+				continue
+			}
+
+			mask := raw.Mask
+			if mask&unix.FAN_Q_OVERFLOW != 0 {
+				select {
+				case fw.Errors <- ErrEventOverflow:
+				case <-fw.done:
+					return
+				}
+			}
+
+			path, errno := os.Readlink(fmt.Sprintf("/proc/self/fd/%d", raw.Fd))
+			if errno != nil {
+				select {
+				case fw.Errors <- errno:
+				case <-fw.done:
+					return
+				}
+			}
+
+			fw.Events <- newFanotifyEvent(path, uintptr(raw.Fd))
+			offset += raw.Event_len
+		}
+	}
+}
+
+func (fw *FanotifyWatcher) isClosed() bool {
+	select {
+	case <-fw.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func newFanotifyEvent(name string, fd uintptr) Event {
+	return Event{Name: name, Op: Write, File: os.NewFile(fd, name)}
+}
+
+func (fw *FanotifyWatcher) Close() error {
+	if fw.isClosed() {
+		return nil
+	}
+
+	// Send 'close' signal to goroutine, and set the Watcher to closed.
+	close(fw.done)
+
+	// Wake up goroutine
+	_ = fw.poller.wake()
+
+	// Wait for goroutine to close
+	<-fw.doneResp
+
+	return nil
+}

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -11,12 +11,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 )
 
 // Event represents a single file system notification.
 type Event struct {
 	Name string // Relative path to the file or directory.
 	Op   Op     // File operation that triggered the event.
+	File *os.File
 }
 
 // Op describes a set of file operations.
@@ -29,6 +31,7 @@ const (
 	Remove
 	Rename
 	Chmod
+	IsDir
 )
 
 func (op Op) String() string {
@@ -50,6 +53,10 @@ func (op Op) String() string {
 	if op&Chmod == Chmod {
 		buffer.WriteString("|CHMOD")
 	}
+	if op&IsDir == IsDir {
+		buffer.WriteString("|ISDIR")
+	}
+
 	if buffer.Len() == 0 {
 		return ""
 	}
@@ -64,5 +71,5 @@ func (e Event) String() string {
 
 // Common errors that can be reported by a watcher
 var (
-	ErrEventOverflow = errors.New("fsnotify queue overflow")
+	ErrEventOverflow = errors.New("queue overflow")
 )

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -18,6 +18,7 @@ func TestEventStringWithValue(t *testing.T) {
 		Rename:         `"/usr/someFile": RENAME`,
 		Remove:         `"/usr/someFile": REMOVE`,
 		Write | Chmod:  `"/usr/someFile": WRITE|CHMOD`,
+		Chmod | Create | IsDir: `"/usr/someFile": CREATE|CHMOD|ISDIR`,
 	} {
 		event := Event{Name: "/usr/someFile", Op: opMask}
 		if event.String() != expectedString {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fsnotify/fsnotify
+module github.com/cloudlinux/fsnotify
 
 go 1.13
 

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestInotifyCloseRightAway(t *testing.T) {
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher")
 	}
@@ -31,7 +31,7 @@ func TestInotifyCloseRightAway(t *testing.T) {
 }
 
 func TestInotifyCloseSlightlyLater(t *testing.T) {
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher")
 	}
@@ -49,7 +49,7 @@ func TestInotifyCloseSlightlyLaterWithWatch(t *testing.T) {
 	testDir := tempMkdir(t)
 	defer os.RemoveAll(testDir)
 
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher")
 	}
@@ -68,7 +68,7 @@ func TestInotifyCloseAfterRead(t *testing.T) {
 	testDir := tempMkdir(t)
 	defer os.RemoveAll(testDir)
 
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher")
 	}
@@ -114,7 +114,7 @@ func TestInotifyCloseCreate(t *testing.T) {
 	testDir := tempMkdir(t)
 	defer os.RemoveAll(testDir)
 
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestInotifyCloseCreate(t *testing.T) {
 	// It's also blocking on unix.Read.
 	// Now we try to swap the file descriptor under its nose.
 	w.Close()
-	w, err = NewWatcher()
+	w, err = NewWatcher(DefaultFlags)
 	defer w.Close()
 	if err != nil {
 		t.Fatalf("Failed to create second watcher: %v", err)
@@ -163,7 +163,7 @@ func TestInotifyStress(t *testing.T) {
 	defer os.RemoveAll(testDir)
 	testFilePrefix := filepath.Join(testDir, "testfile")
 
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestInotifyRemoveTwice(t *testing.T) {
 	}
 	handle.Close()
 
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestInotifyInnerMapLength(t *testing.T) {
 	}
 	handle.Close()
 
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher: %v", err)
 	}
@@ -369,7 +369,7 @@ func TestInotifyOverflow(t *testing.T) {
 	testDir := tempMkdir(t)
 	defer os.RemoveAll(testDir)
 
-	w, err := NewWatcher()
+	w, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("Failed to create watcher: %v", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -56,7 +56,7 @@ func tempMkFile(t *testing.T, dir string) string {
 
 // newWatcher initializes an fsnotify Watcher instance.
 func newWatcher(t *testing.T) *Watcher {
-	watcher, err := NewWatcher()
+	watcher, err := NewWatcher(DefaultFlags)
 	if err != nil {
 		t.Fatalf("NewWatcher() failed: %s", err)
 	}


### PR DESCRIPTION
Changes:

- Fanotify implementation based on inotify.go and inotify_poller.go;
  - added 'File' field in Event to support passing file descriptor from Fanotify event;
- support for setting a custom flag for Inotify events;
- reporting IN_ISDIR event flag in Op for Inotify.
- go.mod module replaced from `github.com/fsnotify/fsnotify` to `github.com/cloudlinux/fsnotify`